### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ usaddress is a python library for parsing unstructured address strings into addr
 
 ## How to use the usaddress python library
 
-1. Install usaddress with [pip](http://pip.readthedocs.org/en/latest/quickstart.html), a tool for installing and managing python packages ([beginner's guide here](http://www.dabapps.com/blog/introduction-to-pip-and-virtualenv-python/))
+1. Install usaddress with [pip](https://pip.readthedocs.io/en/latest/quickstart.html), a tool for installing and managing python packages ([beginner's guide here](http://www.dabapps.com/blog/introduction-to-pip-and-virtualenv-python/))
 
   In the terminal,
   
@@ -87,7 +87,7 @@ If you already have existing labeled data from another project, you'll need to c
 
 * Web Interface: https://parserator.datamade.us/usaddress
 * Python Package Distribution: https://pypi.python.org/pypi/usaddress
-* Python Package Documentation: http://usaddress.rtfd.org/
+* Python Package Documentation: https://usaddress.readthedocs.io/
 * API Documentation: https://parserator.datamade.us/api-docs
 * Repository: https://github.com/datamade/usaddress
 * Issues: https://github.com/datamade/usaddress/issues

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -110,7 +110,7 @@ The address components are based upon the `United States Thoroughfare, Landmark,
 Important links
 ===============
 
-* Documentation: http://usaddress.rtfd.org/
+* Documentation: https://usaddress.readthedocs.io/
 * Repository: https://github.com/datamade/usaddress
 * Issues: https://github.com/datamade/usaddress/issues
 * Distribution: https://pypi.python.org/pypi/usaddress

--- a/usaddress/__init__.py
+++ b/usaddress/__init__.py
@@ -300,6 +300,6 @@ def trailingZeros(token) :
 
 class RepeatedLabelError(probableparsing.RepeatedLabelError) :
     REPO_URL = 'https://github.com/datamade/usaddress/issues/new'
-    DOCS_URL = 'http://usaddress.readthedocs.org/'
+    DOCS_URL = 'https://usaddress.readthedocs.io/'
 
 


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
