### PR TITLE
Parse addresses with HC XXX and XXXX Box __

### DIFF
--- a/measure_performance/test_data/test_HC_XXXX.xml
+++ b/measure_performance/test_data/test_HC_XXXX.xml
@@ -1,0 +1,10 @@
+<AddressCollection>
+  <AddressString><USPSBoxGroupType>HC</USPSBoxGroupType> <USPSBoxGroupID>2333</USPSBoxGroupID> <USPSBoxType>Box</USPSBoxType> <USPSBoxID>85</USPSBoxID></AddressString>
+  <AddressString><USPSBoxGroupType>HC</USPSBoxGroupType> <USPSBoxGroupID>284</USPSBoxGroupID> <USPSBoxType>Box</USPSBoxType> <USPSBoxID>27</USPSBoxID></AddressString>
+  <AddressString><USPSBoxGroupType>HC</USPSBoxGroupType> <USPSBoxGroupID>7326</USPSBoxGroupID> <USPSBoxType>Box</USPSBoxType> <USPSBoxID>66</USPSBoxID></AddressString>
+  <AddressString><USPSBoxGroupType>HC</USPSBoxGroupType> <USPSBoxGroupID>992</USPSBoxGroupID> <USPSBoxType>Box</USPSBoxType> <USPSBoxID>88</USPSBoxID></AddressString>
+  <AddressString><USPSBoxGroupType>HC</USPSBoxGroupType> <USPSBoxGroupID>076</USPSBoxGroupID> <USPSBoxType>Box</USPSBoxType> <USPSBoxID>23</USPSBoxID></AddressString>
+  <AddressString><USPSBoxGroupType>HC</USPSBoxGroupType> <USPSBoxGroupID>026</USPSBoxGroupID> <USPSBoxType>Box</USPSBoxType> <USPSBoxID>74</USPSBoxID></AddressString>
+  <AddressString><USPSBoxGroupType>HC</USPSBoxGroupType> <USPSBoxGroupID>0853</USPSBoxGroupID> <USPSBoxType>Box</USPSBoxType> <USPSBoxID>12</USPSBoxID></AddressString>
+  <AddressString><USPSBoxGroupType>HC</USPSBoxGroupType> <USPSBoxGroupID>0676</USPSBoxGroupID> <USPSBoxType>Box</USPSBoxType> <USPSBoxID>11</USPSBoxID></AddressString>
+</AddressCollection>

--- a/training/HC_XXXX.xml
+++ b/training/HC_XXXX.xml
@@ -1,0 +1,16 @@
+<AddressCollection>
+  <AddressString><USPSBoxGroupType>HC</USPSBoxGroupType> <USPSBoxGroupID>0903</USPSBoxGroupID> <USPSBoxType>Box</USPSBoxType> <USPSBoxID>62</USPSBoxID></AddressString>
+  <AddressString><USPSBoxGroupType>HC</USPSBoxGroupType> <USPSBoxGroupID>9321</USPSBoxGroupID> <USPSBoxType>Box</USPSBoxType> <USPSBoxID>65</USPSBoxID></AddressString>
+  <AddressString><USPSBoxGroupType>HC</USPSBoxGroupType> <USPSBoxGroupID>2800</USPSBoxGroupID> <USPSBoxType>Box</USPSBoxType> <USPSBoxID>87</USPSBoxID></AddressString>
+  <AddressString><USPSBoxGroupType>HC</USPSBoxGroupType> <USPSBoxGroupID>6254</USPSBoxGroupID> <USPSBoxType>Box</USPSBoxType> <USPSBoxID>43</USPSBoxID></AddressString>
+  <AddressString><USPSBoxGroupType>HC</USPSBoxGroupType> <USPSBoxGroupID>095</USPSBoxGroupID> <USPSBoxType>Box</USPSBoxType> <USPSBoxID>23</USPSBoxID></AddressString>
+  <AddressString><USPSBoxGroupType>HC</USPSBoxGroupType> <USPSBoxGroupID>0212</USPSBoxGroupID> <USPSBoxType>Box</USPSBoxType> <USPSBoxID>84</USPSBoxID></AddressString>
+  <AddressString><USPSBoxGroupType>HC</USPSBoxGroupType> <USPSBoxGroupID>021</USPSBoxGroupID> <USPSBoxType>Box</USPSBoxType> <USPSBoxID>52</USPSBoxID></AddressString>
+  <AddressString><USPSBoxGroupType>HC</USPSBoxGroupType> <USPSBoxGroupID>066</USPSBoxGroupID> <USPSBoxType>Box</USPSBoxType> <USPSBoxID>87</USPSBoxID></AddressString>
+  <AddressString><USPSBoxGroupType>HC</USPSBoxGroupType> <USPSBoxGroupID>043</USPSBoxGroupID> <USPSBoxType>Box</USPSBoxType> <USPSBoxID>22</USPSBoxID></AddressString>
+  <AddressString><USPSBoxGroupType>HC</USPSBoxGroupType> <USPSBoxGroupID>994</USPSBoxGroupID> <USPSBoxType>Box</USPSBoxType> <USPSBoxID>87</USPSBoxID></AddressString>
+  <AddressString><USPSBoxGroupType>HC</USPSBoxGroupType> <USPSBoxGroupID>8440</USPSBoxGroupID> <USPSBoxType>Box</USPSBoxType> <USPSBoxID>69</USPSBoxID></AddressString>
+  <AddressString><USPSBoxGroupType>HC</USPSBoxGroupType> <USPSBoxGroupID>0555</USPSBoxGroupID> <USPSBoxType>Box</USPSBoxType> <USPSBoxID>99</USPSBoxID></AddressString>
+  <AddressString><USPSBoxGroupType>HC</USPSBoxGroupType> <USPSBoxGroupID>0956</USPSBoxGroupID> <USPSBoxType>Box</USPSBoxType> <USPSBoxID>32</USPSBoxID></AddressString>
+  <AddressString><USPSBoxGroupType>HC</USPSBoxGroupType> <USPSBoxGroupID>267</USPSBoxGroupID> <USPSBoxType>Box</USPSBoxType> <USPSBoxID>22</USPSBoxID></AddressString>
+</AddressCollection>


### PR DESCRIPTION
 Training for the address with 3 or 4 (numeric only) numbers followed by HC. The numbers can be length of 3 to 4 characters with or without leading zeros.
Example 1:
>>> address1 = usaddress.tag("HC 095 Box 23")
 
Currently It is throwing an error as
 
>>> ORIGINAL STRING:  HC 095 Box 23 
	PARSED TOKENS: [(u'HC', 'USPSBoxType'), (u'095', 'USPSBoxID'), (u'Box', 'USPSBoxType'),    (u'23', 'USPSBoxID')]
	UNCERTAIN LABEL:  USPSBoxType
 
It needs to be parsed this way.
 
>>> pprint(address1)
(OrderedDict([('USPSBoxGroupType', 'HC'),
          	('USPSBoxGroupID', '095'),
          	('USPSBoxType', 'Box'),
          	('USPSBoxID', '23')]),
'PO Box)
 
 
Example 2:
>>> address1 = usaddress.tag("HC 235 Box 1A")
 
Currently It is throwing an error as
 
>>> ORIGINAL STRING:  HC 235 Box 1A
	PARSED TOKENS: (u'HC', 'USPSBoxType'), (u'235', 'USPSBoxID'), (u'Box', 'USPSBoxType'), (u'1A', 'USPSBoxID')]
	UNCERTAIN LABEL:  USPSBoxType
 
It needs to be parsed this way.
 
>>> pprint(address1)
(OrderedDict([('USPSBoxGroupType', 'HC'),
          	('USPSBoxGroupID', '235'),
          	('USPSBoxType', 'Box'),
          	('USPSBoxID', '1A')]),
'PO Box)
 
Example 3:
>>> address1 = usaddress.tag("HC 2302 Box 65")
 
Currently It is parsing as Street Address
 
>>> pprint(address1)
(OrderedDict([('AddressNumber', 'HC'),
          	('StreetName', '2302'),
             ('USPSBoxType', 'Box'),
          	('USPSBoxID', '65')]),
'Street Address')
 
It needs to be parsed this way.
 
>>> pprint(address1)
(OrderedDict([('USPSBoxGroupType', 'HC'),
          	('USPSBoxGroupID', '2302'),
          	('USPSBoxType', 'Box'),
          	('USPSBoxID', '65')]),
'PO Box)
 
Example 4:
>>> address1 = usaddress.tag("HC 0955 Box 12")
 
Currently It is parsing as Street Address
 
>>> pprint(address1)
(OrderedDict([('AddressNumber', 'HC'),
          	('StreetName', '0955'),
             ('USPSBoxType', 'Box'),
          	('USPSBoxID', '12')]),
'Street Address')
 
It needs to be parsed this way.
 
>>> pprint(address1)
(OrderedDict([('USPSBoxGroupType', 'HC'),
          	('USPSBoxGroupID', '0955'),
          	('USPSBoxType', 'Box'),
          	('USPSBoxID', '65')]),
'PO Box)
 
Training xml located at:
	usaddress/training/HC_XXXX.xml
 
Testing xml located at:
	usaddress/measure_performance/test_data/test_HC_XXXX.xml