### PR TITLE
Fix invalid escape sequence

### DIFF
--- a/usaddress/__init__.py
+++ b/usaddress/__init__.py
@@ -244,7 +244,7 @@ def tokenFeatures(token):
                    if token_abbrev.isdigit()
                    else u'w:' + str(len(token_abbrev))),
         'endsinpunc': (token[-1]
-                       if bool(re.match('.+[^.\w]', token, flags=re.UNICODE))
+                       if bool(re.match(r'.+[^.\w]', token, flags=re.UNICODE))
                        else False),
         'directional': token_abbrev in DIRECTIONS,
         'street_name': token_abbrev in STREET_NAMES,


### PR DESCRIPTION
This is a one-character PR that fixes the following warning that appears in Python 3.12: 

```
/usr/local/lib/python3.12/site-packages/usaddress/__init__.py:239: SyntaxWarning: invalid escape sequence '\w'
  if bool(re.match('.+[^.\w]', token, flags=re.UNICODE))
```

We see this error a lot, and others will too when they upgrade. It'd be great to get it fixed. Thank you!